### PR TITLE
Wiki* articles: adjust for mobile

### DIFF
--- a/data/templates/css/wikihow.scss
+++ b/data/templates/css/wikihow.scss
@@ -360,3 +360,11 @@ h2 + ol, h3 + ol, .steps_list_2 {
         }
     }
 }
+
+@media (device-width: 360px) {
+    #bodycontents {
+        .eos-article-title h1 {
+            display: none;
+        }
+    }
+}

--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -569,4 +569,20 @@ $spacing-elements: 30px;
             display: none;
         }
     }
+    .mw-parser-output {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .mw-parser-output > * {
+        order: 2;
+    }
+
+    .mw-parser-output > p:first-of-type {
+        order: 0;
+    }
+
+    .infobox {
+        order: 1;
+    }
 }

--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -463,6 +463,11 @@ $spacing-elements: 30px;
     font-weight: 700;
 }
 
+#toggle,
+.toggle_label {
+   display: none; // Hide input element, only needed in mobile
+}
+
 //////////////////////////////
 // Responsive
 //////////////////////////////
@@ -569,6 +574,7 @@ $spacing-elements: 30px;
             display: none;
         }
     }
+
     .mw-parser-output {
         display: flex;
         flex-direction: column;
@@ -582,7 +588,51 @@ $spacing-elements: 30px;
         order: 0;
     }
 
-    .infobox {
+    .infobox-toggle > .infobox {
+        float: none !important;
+        margin-left: 0px !important;
+        margin-bottom: 0px !important;
+        padding-top: 0.5em;
+    }
+
+    .infobox-toggle-wrapper {
         order: 1;
+        padding: 1em;
+        display: inline-block;
+        box-shadow: 0 1px 2px 0 rgba(153, 153, 153, 0.35);
+    }
+
+    .infobox-toggle {
+        height: 0px;
+        overflow: hidden;
+        transition: height 0.5s;
+    }
+
+    .toggle_label {
+        width: 100%;
+        font-size: 12px;
+        background: #fff;
+        cursor: pointer;
+        display: block;
+        font-weight: bold;
+        -webkit-tap-highlight-color: rgba(0,0,0,0);
+    }
+
+    .toggle_label:after {
+        content: "▲";
+        float: right;
+        font-size: 12px;
+    }
+
+    #toggle:checked ~ .infobox-toggle:first-of-type {
+        height: 0px;
+    }
+
+    #toggle:not(:checked) ~ .infobox-toggle:first-of-type {
+        height: auto;
+    }
+
+    #toggle:checked ~ .toggle_label:after {
+        content: "▼";
     }
 }

--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -563,4 +563,10 @@ $spacing-elements: 30px;
     }
 }
 
-
+@media (device-width: 360px) {
+    #bodycontents {
+        .eos-article-title h1 {
+            display: none;
+        }
+    }
+}

--- a/data/templates/js/collapse-infotable.js
+++ b/data/templates/js/collapse-infotable.js
@@ -1,0 +1,7 @@
+$(function() {
+	// Add a wrapper div around first table infobox
+	$(".infobox:first").wrap("<div class='infobox-toggle-wrapper'><div class='infobox-toggle'></div></div>");
+
+	// Add a checkbox to handle infotable visibility state
+	$("<input id='toggle' type='checkbox' checked><label for='toggle' class='toggle_label'>Quick facts</label>").insertBefore(".infobox-toggle:first");
+});

--- a/eknr.gresource.xml
+++ b/eknr.gresource.xml
@@ -8,6 +8,7 @@
     <file compressed="true">data/templates/css/wikimedia.css</file>
     <file compressed="true">data/templates/js/chunk.js</file>
     <file compressed="true">data/templates/js/clipboard-manager.js</file>
+    <file compressed="true">data/templates/js/collapse-infotable.js</file>
     <file compressed="true">data/templates/js/content-fixes.js</file>
     <file compressed="true">data/templates/js/crosslink.js</file>
     <file compressed="true">data/templates/js/hide-broken-images.js</file>


### PR DESCRIPTION
Responsive stylesheets using media queries. This changes the order in the mobile case, the first paragraph will be placed before the infobox. We will hide the title as it will be displayed on top of the featured image outside of the html content rendered by Android.

The infobox itself will be collapsed by default, inspired by the handling in the Wikimedia app.

When rendering the Wikihow content we only hide the title, there is no infobox in that content.

https://phabricator.endlessm.com/T22356