### PR TITLE
Wikipedia ordering: support SDK3 apps as well

### DIFF
--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -630,7 +630,7 @@ and (max-device-width: 719px) {
         }
     }
 
-    #bodycontents #inside-content div {
+    #bodycontents #inside-content div:first-of-type {
         display: flex;
         flex-direction: column;
     }

--- a/data/templates/css/wikimedia.scss
+++ b/data/templates/css/wikimedia.scss
@@ -630,16 +630,16 @@ and (max-device-width: 719px) {
         }
     }
 
-    .mw-parser-output {
+    #bodycontents #inside-content div {
         display: flex;
         flex-direction: column;
     }
 
-    .mw-parser-output > * {
+    #bodycontents #inside-content * {
         order: 2;
     }
 
-    .mw-parser-output > p:first-of-type {
+    #bodycontents #inside-content p:first-of-type {
         order: 0;
     }
 

--- a/data/templates/js/collapse-infotable.js
+++ b/data/templates/js/collapse-infotable.js
@@ -1,4 +1,10 @@
 $(function() {
+        // Make sure we only have one div for ordering of the elements
+        var divP = $(".mw-parser-output");
+        if (divP.parent().is("div")) {
+            divP.unwrap();
+        }
+
 	// Add a wrapper div around first table infobox
 	$(".infobox:first").wrap("<div class='infobox-toggle-wrapper'><div class='infobox-toggle'></div></div>");
 


### PR DESCRIPTION
In the SDK3 wikipedia apps we do not have ".mw-parser-output", we should
not rely on it being present as the apps in 3.4 still are SDK3 apps.

https://phabricator.endlessm.com/T22647